### PR TITLE
gnoigo requires go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openconfig/gnoigo
 
-go 1.18
+go 1.21
 
 require (
 	github.com/golang/glog v1.1.0


### PR DESCRIPTION
Go version 1.21 is needed for improved generics inference.
Fixes https://github.com/openconfig/gnoigo/issues/21